### PR TITLE
Pmp2 286 manage negative acks

### DIFF
--- a/include/iec104.h
+++ b/include/iec104.h
@@ -35,7 +35,8 @@ class DatapointValue;
 class InformationObject_RAII {
     public:
 
-    InformationObject_RAII(InformationObject io): m_io(io) {}
+    explicit InformationObject_RAII(InformationObject io): m_io(io) {}
+    InformationObject_RAII& operator=(InformationObject_RAII&&) = delete;
     ~InformationObject_RAII() {
         if (m_io) {
             InformationObject_destroy(m_io);

--- a/include/iec104.h
+++ b/include/iec104.h
@@ -32,6 +32,18 @@ class IEC104DataPoint;
 class Datapoint;
 class DatapointValue;
 
+class InformationObject_RAII {
+    public:
+
+    InformationObject_RAII(InformationObject io): m_io(io) {}
+    ~InformationObject_RAII() {
+        if (m_io) {
+            InformationObject_destroy(m_io);
+        }
+    }
+    InformationObject m_io = nullptr;
+};
+
 class IEC104OutstandingCommand
 {
 public:
@@ -119,6 +131,7 @@ private:
     void handleActTerm(int type, int ca, int ioa, bool isNegative);
     bool requestSouthConnectionStatus();
     void updateSouthMonitoringInstance(Datapoint* dp, IEC104Config::SouthPluginMonitor* southPluginMonitor);
+    bool validateCommand(IMasterConnection connection, CS101_ASDU asdu);
 
     static void printCP56Time2a(CP56Time2a time);
     static void rawMessageHandler(void* parameter, IMasterConnection connection,

--- a/src/iec104.cpp
+++ b/src/iec104.cpp
@@ -408,10 +408,7 @@ IEC104Server::operation(char *operation, int paramCount, char *names[], char *pa
         res = m_oper(operation, paramCount, names, parameters, DestinationService, m_config->CmdDest().c_str());
     }
     Iec104Utility::log_debug("%s Operation returned %d", beforeLog.c_str(), res);
-    // Fledge operations always return -1 for now, this may be fixed by https://github.com/fledge-iot/fledge/issues/1210
-    // In the meantime consider they always succeed by returning 1 instead of res
-    // return res;
-    return 1;
+    return res;
 }
 
 bool

--- a/src/iec104.cpp
+++ b/src/iec104.cpp
@@ -1359,8 +1359,7 @@ IEC104Server::validateCommand(IMasterConnection connection, CS101_ASDU asdu) {
             if (!checkIfCmdTimeIsValid(typeId, io)) {
                 Iec104Utility::log_warn("%s command (%s) for %i:%i - Invalid timestamp -> ignore", beforeLog.c_str(),
                                         IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa);//LCOV_EXCL_LINE
-                acceptCommand = false;
-
+                                        
                 /* send negative response -> according to IEC 60870-5-104 the command should be silently ignored instead! */
                 CS101_ASDU_setCOT(asdu, CS101_COT_ACTIVATION_CON);
                 CS101_ASDU_setNegative(asdu, true);

--- a/src/iec104.cpp
+++ b/src/iec104.cpp
@@ -1276,6 +1276,136 @@ IEC104Server::updateSouthMonitoringInstance(Datapoint* dp, IEC104Config::SouthPl
 }
 
 /**
+ * Validate an ASDU command
+ *
+ * @param connection    The connection where the command was received 
+ * @param asdu	        The asdu to validate
+ * @return 		        True if a response should be sent, else false
+ */
+bool
+IEC104Server::validateCommand(IMasterConnection connection, CS101_ASDU asdu) {
+    std::string beforeLog = Iec104Utility::PluginName + " - IEC104Server::validateCommand -";
+    
+    IEC60870_5_TypeID typeId = CS101_ASDU_getTypeID(asdu);
+    if (!checkIfSouthConnected()) {
+        Iec104Utility::log_warn("%s command (%s) received while south plugin is not connected -> reject", beforeLog.c_str(),
+                                IEC104DataPoint::getStringFromTypeID(typeId).c_str());//LCOV_EXCL_LINE
+        CS101_ASDU_setCOT(asdu, CS101_COT_ACTIVATION_CON);
+        CS101_ASDU_setNegative(asdu, true);
+        return true;
+    }
+    
+    CS101_CauseOfTransmission cot = CS101_ASDU_getCOT(asdu);
+    if (cot != CS101_COT_ACTIVATION) {
+        Iec104Utility::log_warn("%s command (%s) - Unexpected COT: %d", beforeLog.c_str(),
+                                IEC104DataPoint::getStringFromTypeID(typeId).c_str(), cot);//LCOV_EXCL_LINE
+        CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_COT);
+        return true;
+    }
+
+    InformationObject io = CS101_ASDU_getElement(asdu, 0);
+    InformationObject_RAII io_raii(io);
+    if (!io) {
+        Iec104Utility::log_warn("%s command (%s) - Unknown type or information object missing", beforeLog.c_str(),
+                                IEC104DataPoint::getStringFromTypeID(typeId).c_str()); //LCOV_EXCL_LINE
+        CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_TYPE_ID);
+        CS101_ASDU_setNegative(asdu, true);
+        return true;
+    }
+
+    int ca = CS101_ASDU_getCA(asdu);
+    std::map<int, IEC104DataPoint*> ld = m_exchangeDefinitions[ca];
+    if (ld.empty()) {
+        Iec104Utility::log_warn("%s command (%s) - Unknown CA: %i", beforeLog.c_str(),
+                                IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca); //LCOV_EXCL_LINE
+        CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_CA);
+        return true;
+    }
+
+    /* check if command has an allowed OA */
+    int oa = CS101_ASDU_getOA(asdu);
+    if (!m_config->IsOriginatorAllowed(oa)) {
+        Iec104Utility::log_warn("%s command (%s) for %i - Originator address %i not allowed", beforeLog.c_str(),
+                                IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, oa); //LCOV_EXCL_LINE
+        return true;
+    }
+
+    int ioa = InformationObject_getObjectAddress(io);
+    IEC104DataPoint* dp = ld[ioa];
+    if (!dp) {
+        Iec104Utility::log_warn("%s command (%s) for %i:%i - Unknown IOA", beforeLog.c_str(),
+                                IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa); //LCOV_EXCL_LINE
+        CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_IOA);
+        CS101_ASDU_setNegative(asdu, true);
+        return true;
+    }
+    if (!dp->isMatchingCommand(typeId)) {
+        Iec104Utility::log_warn("%s command (%s) for %i:%i - Unknown command type %d", beforeLog.c_str(),
+                                IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa, typeId); //LCOV_EXCL_LINE
+        CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_TYPE_ID);
+        CS101_ASDU_setNegative(asdu, true);
+        return true;
+    }
+
+    bool sendResponse = true;
+    bool acceptCommand = true;
+    if (IEC104DataPoint::isCommandWithTimestamp(typeId)) {
+        if (!m_config->AllowCmdWithTime()) {
+            Iec104Utility::log_warn("%s command (%s) for %i:%i - Commands with timestamp are not allowed", beforeLog.c_str(),
+                                    IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa); //LCOV_EXCL_LINE
+            acceptCommand = false;
+        }
+        else {
+            if (!checkIfCmdTimeIsValid(typeId, io)) {
+                Iec104Utility::log_warn("%s command (%s) for %i:%i - Invalid timestamp -> ignore", beforeLog.c_str(),
+                                        IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa);//LCOV_EXCL_LINE
+                acceptCommand = false;
+
+                /* send negative response -> according to IEC 60870-5-104 the command should be silently ignored instead! */
+                CS101_ASDU_setCOT(asdu, CS101_COT_ACTIVATION_CON);
+                CS101_ASDU_setNegative(asdu, true);
+
+                IMasterConnection_sendASDU(connection, asdu);
+
+                sendResponse = false;
+            }
+            else {
+                Iec104Utility::log_debug("%s command (%s) for %i:%i - Valid timestamp -> accept", beforeLog.c_str(),
+                                        IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa);//LCOV_EXCL_LINE
+            }
+        }
+    }
+    else {
+        if (!m_config->AllowCmdWithoutTime()) {
+            Iec104Utility::log_warn("%s command (%s) for %i:%i - Commands without timestamp are not allowed", beforeLog.c_str(),
+                                    IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa); //LCOV_EXCL_LINE
+            acceptCommand = false;
+        }
+    }
+
+    if (acceptCommand) {
+        CS101_ASDU_setCOT(asdu, CS101_COT_ACTIVATION_CON);
+        if (!forwardCommand(asdu, io, connection)) {
+            Iec104Utility::log_warn("%s command (%s) for %i:%i - Failed to forward command, set negative response", beforeLog.c_str(),
+                                    IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa); //LCOV_EXCL_LINE
+            CS101_ASDU_setNegative(asdu, true);       
+        }
+        else {
+            /* send ACT-CON later when south side feedback is received */
+            sendResponse = false;
+        }
+    }
+    else {
+        Iec104Utility::log_warn("%s command (%s) for %i:%i - Command not accepted", beforeLog.c_str(),
+                                IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa); //LCOV_EXCL_LINE
+        CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_TYPE_ID);
+        CS101_ASDU_setNegative(asdu, true);
+    }
+    
+    return sendResponse;
+}
+
+/**
  * Send a block of reading to IEC104 Server
  *
  * @param readings	The readings to send
@@ -1904,149 +2034,23 @@ IEC104Server::asduHandler(void* parameter, IMasterConnection connection,
     IEC104Server* self = (IEC104Server*)parameter;
 
     IEC60870_5_TypeID typeId = CS101_ASDU_getTypeID(asdu);
-    if (isSupportedCommandType(typeId))
-    {
-        Iec104Utility::log_info("%s Received command of type %s", beforeLog.c_str(),
-                                IEC104DataPoint::getStringFromTypeID(typeId).c_str());//LCOV_EXCL_LINE
-
-        bool sendResponse = true;
-
-        CS101_CauseOfTransmission cot = CS101_ASDU_getCOT(asdu);
-        if (cot == CS101_COT_ACTIVATION)
-        {
-            InformationObject io = CS101_ASDU_getElement(asdu, 0);
-
-            if (io) {
-
-                int ca = CS101_ASDU_getCA(asdu);
-
-                std::map<int, IEC104DataPoint*> ld = self->m_exchangeDefinitions[ca];
-
-                if (!ld.empty()) {
-                    /* check if command has an allowed OA */
-                    int oa = CS101_ASDU_getOA(asdu);
-                    if (self->m_config->IsOriginatorAllowed(oa))
-                    {
-                        int ioa = InformationObject_getObjectAddress(io);
-
-                        IEC104DataPoint* dp = ld[ioa];
-
-                        if (dp)
-                        {
-                            if (dp->isMatchingCommand(typeId)) {
-
-                                bool acceptCommand = true;
-
-                                if (IEC104DataPoint::isCommandWithTimestamp(typeId)) {
-                                    if (!self->m_config->AllowCmdWithTime()) {
-                                        Iec104Utility::log_warn("%s command (%s) for %i:%i - Commands with timestamp are not allowed",
-                                                                beforeLog.c_str(),
-                                                                IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa); //LCOV_EXCL_LINE
-                                        acceptCommand = false;
-                                    }
-                                    else {
-                                        if (!self->checkIfCmdTimeIsValid(typeId, io)) {
-                                            Iec104Utility::log_warn("%s command (%s) for %i:%i - Invalid timestamp -> ignore",
-                                                                    beforeLog.c_str(),
-                                                                    IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa);//LCOV_EXCL_LINE
-                                            acceptCommand = false;
-
-                                            /* send negative response -> according to IEC 60870-5-104 the command should be silently ignored instead! */
-                                            CS101_ASDU_setCOT(asdu, CS101_COT_ACTIVATION_CON);
-                                            CS101_ASDU_setNegative(asdu, true);
-
-                                            IMasterConnection_sendASDU(connection, asdu);
-
-                                            sendResponse = false;
-                                        }
-                                        else {
-                                            Iec104Utility::log_debug("%s command (%s) for %i:%i - Valid timestamp -> accept",
-                                                                    beforeLog.c_str(),
-                                                                    IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa);//LCOV_EXCL_LINE
-                                        }
-                                    }
-                                }
-                                else {
-                                    if (!self->m_config->AllowCmdWithoutTime()) {
-                                        Iec104Utility::log_warn(
-                                            "%s command (%s) for %i:%i - Commands without timestamp are not allowed",
-                                            beforeLog.c_str(), IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa); //LCOV_EXCL_LINE
-                                        acceptCommand = false;
-                                    }
-                                }
-
-                                if (acceptCommand) {
-                                    CS101_ASDU_setCOT(asdu, CS101_COT_ACTIVATION_CON);
-
-                                    if (!self->forwardCommand(asdu, io, connection)) {
-                                        CS101_ASDU_setNegative(asdu, true);
-                                        Iec104Utility::log_warn(
-                                            "%s command (%s) for %i:%i - Failed to forward command, set negative response",
-                                            beforeLog.c_str(), IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa); //LCOV_EXCL_LINE
-                                    }
-                                    else {
-                                        /* send ACT-CON later when south side feedback is received */
-                                        sendResponse = false;
-                                    }
-                                }
-                                else {
-                                    Iec104Utility::log_warn("%s command (%s) for %i:%i - Command not accepted", beforeLog.c_str(),
-                                                            IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa); //LCOV_EXCL_LINE
-                                    CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_TYPE_ID);
-                                }
-                            }
-                            else {
-                                Iec104Utility::log_warn("%s command (%s) for %i:%i - Unknown command type %d", beforeLog.c_str(),
-                                                        IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa, typeId); //LCOV_EXCL_LINE
-                                CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_TYPE_ID);
-                            }
-                        }
-                        else {
-                            Iec104Utility::log_warn("%s command (%s) for %i:%i - Unknown IOA", beforeLog.c_str(),
-                                                    IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, ioa); //LCOV_EXCL_LINE
-                            CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_IOA);
-                        }
-                    }
-                    else {
-                        Iec104Utility::log_warn("%s command (%s) for %i - Originator address %i not allowed", beforeLog.c_str(),
-                                                IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, oa); //LCOV_EXCL_LINE
-                    }
-                }
-                else {
-                    Iec104Utility::log_warn("%s command (%s) - Unknown CA: %i", beforeLog.c_str(),
-                                            IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca); //LCOV_EXCL_LINE
-                    CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_CA);
-                }
-
-                InformationObject_destroy(io);
-            }
-            else {
-                Iec104Utility::log_warn("%s command (%s) - Unknown type or information object missing", beforeLog.c_str(),
-                                        IEC104DataPoint::getStringFromTypeID(typeId).c_str()); //LCOV_EXCL_LINE
-                CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_TYPE_ID);
-            }
-        }
-        else {
-            CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_COT);
-            Iec104Utility::log_warn("%s command (%s) - Unexpected COT: %d", beforeLog.c_str(),
-                                    IEC104DataPoint::getStringFromTypeID(typeId).c_str(), cot);//LCOV_EXCL_LINE
-        }
-
-        if (sendResponse)
-        {
-            Iec104Utility::log_debug("%s command (%s) - Sending response", beforeLog.c_str(),
-                                    IEC104DataPoint::getStringFromTypeID(typeId).c_str());//LCOV_EXCL_LINE
-            IMasterConnection_sendASDU(connection, asdu);
-        }
-
-        return true;
-    }
-    else {
-        Iec104Utility::log_warn("%s command (%s) - unsupported command type: %d", beforeLog.c_str(),
+    if (!isSupportedCommandType(typeId)) {
+        Iec104Utility::log_warn("%s command (%s) - unsupported command type: %d -> ignore", beforeLog.c_str(),
                                 IEC104DataPoint::getStringFromTypeID(typeId).c_str(), typeId);//LCOV_EXCL_LINE
+        return false;
     }
 
-    return false;
+    Iec104Utility::log_info("%s Received command of type %s", beforeLog.c_str(),
+                            IEC104DataPoint::getStringFromTypeID(typeId).c_str());//LCOV_EXCL_LINE
+
+    bool sendResponse = self->validateCommand(connection, asdu);
+    if (sendResponse) {
+        Iec104Utility::log_debug("%s command (%s) - Sending response", beforeLog.c_str(),
+                                IEC104DataPoint::getStringFromTypeID(typeId).c_str());//LCOV_EXCL_LINE
+        IMasterConnection_sendASDU(connection, asdu);
+    }
+
+    return true;
 }
 
 /**

--- a/src/iec104.cpp
+++ b/src/iec104.cpp
@@ -1300,6 +1300,7 @@ IEC104Server::validateCommand(IMasterConnection connection, CS101_ASDU asdu) {
         Iec104Utility::log_warn("%s command (%s) - Unexpected COT: %d", beforeLog.c_str(),
                                 IEC104DataPoint::getStringFromTypeID(typeId).c_str(), cot);//LCOV_EXCL_LINE
         CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_COT);
+        CS101_ASDU_setNegative(asdu, true);
         return true;
     }
 
@@ -1319,6 +1320,7 @@ IEC104Server::validateCommand(IMasterConnection connection, CS101_ASDU asdu) {
         Iec104Utility::log_warn("%s command (%s) - Unknown CA: %i", beforeLog.c_str(),
                                 IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca); //LCOV_EXCL_LINE
         CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_CA);
+        CS101_ASDU_setNegative(asdu, true);
         return true;
     }
 
@@ -1327,6 +1329,8 @@ IEC104Server::validateCommand(IMasterConnection connection, CS101_ASDU asdu) {
     if (!m_config->IsOriginatorAllowed(oa)) {
         Iec104Utility::log_warn("%s command (%s) for %i - Originator address %i not allowed", beforeLog.c_str(),
                                 IEC104DataPoint::getStringFromTypeID(typeId).c_str(), ca, oa); //LCOV_EXCL_LINE
+        CS101_ASDU_setCOT(asdu, CS101_COT_ACTIVATION_CON);
+        CS101_ASDU_setNegative(asdu, true);
         return true;
     }
 

--- a/src/iec104.cpp
+++ b/src/iec104.cpp
@@ -1348,7 +1348,6 @@ IEC104Server::validateCommand(IMasterConnection connection, CS101_ASDU asdu) {
         return true;
     }
 
-    bool sendResponse = true;
     bool acceptCommand = true;
     if (IEC104DataPoint::isCommandWithTimestamp(typeId)) {
         if (!m_config->AllowCmdWithTime()) {
@@ -1368,7 +1367,7 @@ IEC104Server::validateCommand(IMasterConnection connection, CS101_ASDU asdu) {
 
                 IMasterConnection_sendASDU(connection, asdu);
 
-                sendResponse = false;
+                return false;
             }
             else {
                 Iec104Utility::log_debug("%s command (%s) for %i:%i - Valid timestamp -> accept", beforeLog.c_str(),
@@ -1393,7 +1392,7 @@ IEC104Server::validateCommand(IMasterConnection connection, CS101_ASDU asdu) {
         }
         else {
             /* send ACT-CON later when south side feedback is received */
-            sendResponse = false;
+            return false;
         }
     }
     else {
@@ -1403,7 +1402,7 @@ IEC104Server::validateCommand(IMasterConnection connection, CS101_ASDU asdu) {
         CS101_ASDU_setNegative(asdu, true);
     }
     
-    return sendResponse;
+    return true;
 }
 
 /**

--- a/tests/test_control.cpp
+++ b/tests/test_control.cpp
@@ -86,6 +86,156 @@ static string protocol_stack = QUOTE({
         }
     });
 
+static string protocol_stack_2 = QUOTE({
+        "protocol_stack" : {
+            "name" : "iec104server",
+            "version" : "1.0",
+            "transport_layer" : {
+                "redundancy_groups":[
+                    {
+                       "connections":[
+                          {
+                             "clt_ip":"192.168.2.244"
+                          },
+                          {
+                             "clt_ip":"192.168.0.11"
+                          }
+                       ],
+                       "rg_name":"red-group-1"
+                    },
+                    {
+                       "connections":[
+                          {
+                             "clt_ip":"192.168.2.224"
+                          },
+                          {
+                             "clt_ip":"192.168.0.11"
+                          },
+                          {
+                             "clt_ip":"192.168.0.12"
+                          }
+                       ],
+                       "rg_name":"red-group-2"
+                    },
+                    {
+                        "rg_name":"catch-all"
+                    }
+                ],
+                "bind_on_ip":false,
+                "srv_ip":"0.0.0.0",
+                "port":2404,
+                "tls":false,
+                "k_value":12,
+                "w_value":8,
+                "t0_timeout":10,
+                "t1_timeout":15,
+                "t2_timeout":10,
+                "t3_timeout":20,
+                "mode": "accept_always"
+            },
+            "application_layer" : {
+                "ca_asdu_size":2,
+                "ioaddr_size":3,
+                "asdu_size":0,
+                "time_sync":false,
+                "cmd_exec_timeout":1,
+                "cmd_recv_timeout":1,
+                "accept_cmd_with_time":0,
+                "filter_orig":false,
+                "filter_list":[
+                    {
+                       "orig_addr":0
+                    },
+                    {
+                       "orig_addr":1
+                    },
+                    {
+                       "orig_addr":2
+                    }
+                ]
+            },
+            "south_monitoring": [
+                {"asset": "CONSTAT-1"},
+                {"asset": "CONSTAT-2"}
+            ]
+        }
+    });
+
+static string protocol_stack_3 = QUOTE({
+        "protocol_stack" : {
+            "name" : "iec104server",
+            "version" : "1.0",
+            "transport_layer" : {
+                "redundancy_groups":[
+                    {
+                       "connections":[
+                          {
+                             "clt_ip":"192.168.2.244"
+                          },
+                          {
+                             "clt_ip":"192.168.0.11"
+                          }
+                       ],
+                       "rg_name":"red-group-1"
+                    },
+                    {
+                       "connections":[
+                          {
+                             "clt_ip":"192.168.2.224"
+                          },
+                          {
+                             "clt_ip":"192.168.0.11"
+                          },
+                          {
+                             "clt_ip":"192.168.0.12"
+                          }
+                       ],
+                       "rg_name":"red-group-2"
+                    },
+                    {
+                        "rg_name":"catch-all"
+                    }
+                ],
+                "bind_on_ip":false,
+                "srv_ip":"0.0.0.0",
+                "port":2404,
+                "tls":false,
+                "k_value":12,
+                "w_value":8,
+                "t0_timeout":10,
+                "t1_timeout":15,
+                "t2_timeout":10,
+                "t3_timeout":20,
+                "mode": "accept_always"
+            },
+            "application_layer" : {
+                "ca_asdu_size":2,
+                "ioaddr_size":3,
+                "asdu_size":0,
+                "time_sync":false,
+                "cmd_exec_timeout":1,
+                "cmd_recv_timeout":1,
+                "accept_cmd_with_time":1,
+                "filter_orig":false,
+                "filter_list":[
+                    {
+                       "orig_addr":0
+                    },
+                    {
+                       "orig_addr":1
+                    },
+                    {
+                       "orig_addr":2
+                    }
+                ]
+            },
+            "south_monitoring": [
+                {"asset": "CONSTAT-1"},
+                {"asset": "CONSTAT-2"}
+            ]
+        }
+    });
+
 static string tls = QUOTE({
         "tls_conf" : {
             "private_key" : "iec104_server.key",
@@ -349,7 +499,8 @@ protected:
         requestSouthStatusCalled = 0;
         asduHandlerCalled = 0;
         actConReceived = 0;
-        actConNegative = false;
+        lastCOTReceived = 0;
+        isNegative = false;
         actTermReceived = 0;
 
         // Init iec104server object
@@ -370,11 +521,13 @@ protected:
     static int operateHandlerSingleCommand(char *operation, int paramCount, char* names[], char *parameters[], ControlDestination destination, ...);
     static int operateHandlerReceiveSetpointCommandShortWithTimestamp(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...);
     static int operateHandlerReceiveSetpointCommandShortWithInvalidTimestamp(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...);
+    static int operateHandlerSinglePointCommandUnknownCOT(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...);
     static int operateHandlerSinglePointCommandUnknownCA(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...);
+    static int operateHandlerSinglePointCommandOriginatorNotAllowed(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...);
     static int operateHandlerReceiveUnexpectedDoublePointCommand(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...);
     static int operateHandlerCommandAckTimeout(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...);
     static int operateHandlerCommandActCon(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...);
-    static int operateHandlerCommandActConNegative(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...);
+    static int operateHandlerCommandisNegative(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...);
     static int operateHandlerSinglePointCommandIOMissing(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...);
     static int operateHandlerReceiveSinglePointCommandWithTime(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...);
     static int operateHandlerDoublePointCommand(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...);
@@ -399,9 +552,12 @@ protected:
 
     void ForwardCommandAck(const char* cmdName, const char* type, int ca, int ioa, int cot, bool negative);
 
+    void SendSouthEvent(std::string asset, bool withConnx, std::string connxValue, bool withGiStatus, std::string giStatusValue);
+
     int asduHandlerCalled = 0;
     int actConReceived = 0;
-    bool actConNegative = false;
+    int lastCOTReceived = 0;
+    bool isNegative = false;
     int actTermReceived = 0;
 
     static bool m_asduReceivedHandler(void* parameter, int address, CS101_ASDU asdu);
@@ -418,11 +574,13 @@ ControlTest::m_asduReceivedHandler(void* parameter, int address, CS101_ASDU asdu
     printf("CS101_ASDU: type: %s (%d) ca: %i cot: %i\n", IEC104DataPoint::getStringFromTypeID(typeId).c_str(), typeId,
             CS101_ASDU_getCA(asdu), CS101_ASDU_getCOT(asdu));
     
-    self->actConNegative = false;
+    self->isNegative = false;
 
-    if (CS101_ASDU_getCOT(asdu) == CS101_COT_ACTIVATION_CON) {
+    auto cot = CS101_ASDU_getCOT(asdu);
+    self->lastCOTReceived = cot;
+    self->isNegative = CS101_ASDU_isNegative(asdu);
+    if (cot == CS101_COT_ACTIVATION_CON) {
         self->actConReceived++;
-        self->actConNegative = CS101_ASDU_isNegative(asdu);
     }
 
     if (CS101_ASDU_getCOT(asdu) == CS101_COT_ACTIVATION_TERMINATION) {
@@ -545,7 +703,47 @@ int ControlTest::operateHandlerReceiveSetpointCommandShortWithInvalidTimestamp(c
     return 1;
 }
 
+int ControlTest::operateHandlerSinglePointCommandUnknownCOT(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...)
+{
+    printf("%s\n",operation);
+    EXPECT_EQ(operation,"request_connection_status");
+    if(!strcmp(operation, "IEC104Command")) {
+        for(int i = 0; i < paramCount; i++) {
+            printf("PARAM: %s: %s\n", names[i], parameters[i]);
+        }
+
+    }
+    if (!strcmp(operation, "request_connection_status")) {
+        requestSouthStatusCalled++;
+    }
+    else {
+        operateHandlerCalled++;
+    }
+
+    return 1;
+}
+
 int ControlTest::operateHandlerSinglePointCommandUnknownCA(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...)
+{
+    printf("%s\n",operation);
+    EXPECT_EQ(operation,"request_connection_status");
+    if(!strcmp(operation, "IEC104Command")) {
+        for(int i = 0; i < paramCount; i++) {
+            printf("PARAM: %s: %s\n", names[i], parameters[i]);
+        }
+
+    }
+    if (!strcmp(operation, "request_connection_status")) {
+        requestSouthStatusCalled++;
+    }
+    else {
+        operateHandlerCalled++;
+    }
+
+    return 1;
+}
+
+int ControlTest::operateHandlerSinglePointCommandOriginatorNotAllowed(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...)
 {
     printf("%s\n",operation);
     EXPECT_EQ(operation,"request_connection_status");
@@ -663,7 +861,7 @@ int ControlTest::operateHandlerCommandActCon(char *operation, int paramCount, ch
     return 1;
 }
 
-int ControlTest::operateHandlerCommandActConNegative(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...)
+int ControlTest::operateHandlerCommandisNegative(char *operation, int paramCount, char *names[], char *parameters[], ControlDestination destination, ...)
 {
     printf("%s\n",operation);
     if(!strcmp(operation, "IEC104Command")) {
@@ -1222,6 +1420,45 @@ ControlTest::ForwardCommandAck(const char* cmdName, const char* type, int ca, in
     delete dataobjects;
 }
 
+static Datapoint*
+createSouthEvent(bool withConnx, std::string connxValue, bool withGiStatus, std::string giStatusValue)
+{
+    auto* datapoints = new vector<Datapoint*>;
+
+    if (withConnx) {
+        datapoints->push_back(createDatapoint("connx_status", connxValue));
+    }
+
+    if (withGiStatus) {
+        datapoints->push_back(createDatapoint("gi_status", giStatusValue));
+    }
+
+    DatapointValue dpv(datapoints, true);
+
+    Datapoint* dp = new Datapoint("south_event", dpv);
+
+    return dp;
+}
+
+void
+ControlTest::SendSouthEvent(std::string asset, bool withConnx, std::string connxValue, bool withGiStatus, std::string giStatusValue)
+{
+    Datapoint* southEvent = createSouthEvent(true, connxValue, withGiStatus, giStatusValue);
+
+    auto* southEvents = new vector<Datapoint*>;
+
+    southEvents->push_back(southEvent);
+
+    //TODO send south event connx_started
+    Reading* reading = new Reading(asset, *southEvents);
+
+    vector<Reading*> readings;
+
+    readings.push_back(reading);
+
+    iec104Server->send(readings);
+}
+
 TEST_F(ControlTest, CreateReading)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
@@ -1249,6 +1486,8 @@ TEST_F(ControlTest, ReceiveSinglePointCommand)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerSingleCommand);
 
@@ -1267,12 +1506,15 @@ TEST_F(ControlTest, ReceiveSinglePointCommand)
     Thread_sleep(500);
 
     ASSERT_EQ(1, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 }
 
 TEST_F(ControlTest, ReceiveSetpointCommandShortWithTimestamp)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data_2, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerReceiveSetpointCommandShortWithTimestamp);
 
@@ -1298,12 +1540,15 @@ TEST_F(ControlTest, ReceiveSetpointCommandShortWithTimestamp)
     Thread_sleep(1500);
 
     ASSERT_EQ(1, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 }
 
 TEST_F(ControlTest, ReceiveSetpointCommandShortWithInvalidTimestamp)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data_2, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerReceiveSetpointCommandShortWithInvalidTimestamp);
 
@@ -1334,15 +1579,77 @@ TEST_F(ControlTest, ReceiveSetpointCommandShortWithInvalidTimestamp)
     /* expect negative ACT-CON */
     ASSERT_EQ(1, asduHandlerCalled);
     ASSERT_EQ(1, actConReceived);
-    ASSERT_TRUE(actConNegative);
+    ASSERT_TRUE(isNegative);
 }
 
+TEST_F(ControlTest, SinglePointCommandSouthNotConnected)
+{
+    iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
+    ASSERT_TRUE(iec104Server->startSlave());
+    // Do not open connecion with south plugin
+    //SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
+    iec104Server->registerControl(operateHandlerSingleCommand);
+
+    Thread_sleep(500); /* wait for the server to start */
+
+    ASSERT_TRUE(CS104_Connection_connect(connection));
+
+    CS104_Connection_sendStartDT(connection);
+
+    InformationObject sc = (InformationObject)SingleCommand_create(NULL, 23005, true, false, 0);
+
+    CS104_Connection_sendProcessCommandEx(connection, CS101_COT_ACTIVATION, 45, sc);
+
+    InformationObject_destroy(sc);
+
+    Thread_sleep(500);
+
+    ASSERT_EQ(0, operateHandlerCalled);
+
+    /* expect negative ACT-CON */
+    ASSERT_EQ(1, asduHandlerCalled);
+    ASSERT_EQ(1, actConReceived);
+    ASSERT_TRUE(isNegative);
+}
+
+TEST_F(ControlTest, SinglePointCommandUnknownCOT)
+{
+    iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
+    ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
+
+    iec104Server->registerControl(operateHandlerSinglePointCommandUnknownCOT);
+
+    Thread_sleep(500); /* wait for the server to start */
+
+    ASSERT_TRUE(CS104_Connection_connect(connection));
+
+    CS104_Connection_sendStartDT(connection);
+
+    InformationObject sc = (InformationObject)SingleCommand_create(NULL, 23005, true, false, 0);
+
+    CS104_Connection_sendProcessCommandEx(connection, CS101_COT_ACTIVATION_CON, 45, sc);
+
+    InformationObject_destroy(sc);
+
+    Thread_sleep(500);
+
+    ASSERT_EQ(0, operateHandlerCalled);
+
+    /* expect negative ACT-CON */
+    ASSERT_EQ(1, asduHandlerCalled);
+    ASSERT_EQ(lastCOTReceived, CS101_COT_UNKNOWN_COT);
+    ASSERT_TRUE(isNegative);
+}
 
 TEST_F(ControlTest, SinglePointCommandUnknownCA)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerSinglePointCommandUnknownCA);
 
@@ -1361,12 +1668,53 @@ TEST_F(ControlTest, SinglePointCommandUnknownCA)
     Thread_sleep(500);
 
     ASSERT_EQ(0, operateHandlerCalled);
+
+    /* expect negative ACT-CON */
+    ASSERT_EQ(1, asduHandlerCalled);
+    ASSERT_EQ(lastCOTReceived, CS101_COT_UNKNOWN_CA);
+    ASSERT_TRUE(isNegative);
+}
+
+TEST_F(ControlTest, SinglePointCommandOriginatorNotAllowed)
+{
+    iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
+    ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
+
+    iec104Server->registerControl(operateHandlerSinglePointCommandOriginatorNotAllowed);
+
+    Thread_sleep(500); /* wait for the server to start */
+
+    CS101_AppLayerParameters alParams = CS104_Connection_getAppLayerParameters(connection);
+    alParams->originatorAddress = 3; // Only 0, 1 and 2 are allowed
+    CS104_Connection_setAppLayerParameters(connection, alParams);
+    ASSERT_TRUE(CS104_Connection_connect(connection));
+    
+    CS104_Connection_sendStartDT(connection);
+
+    InformationObject sc = (InformationObject)SingleCommand_create(NULL, 23005, true, false, 0);
+
+    CS104_Connection_sendProcessCommandEx(connection, CS101_COT_ACTIVATION, 45, sc);
+
+    InformationObject_destroy(sc);
+
+    Thread_sleep(500);
+
+    ASSERT_EQ(0, operateHandlerCalled);
+
+    /* expect negative ACT-CON */
+    ASSERT_EQ(1, asduHandlerCalled);
+    ASSERT_EQ(1, actConReceived);
+    ASSERT_TRUE(isNegative);
 }
 
 TEST_F(ControlTest, ReceiveUnexpectedDoublePointCommand)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerReceiveUnexpectedDoublePointCommand);
 
@@ -1385,12 +1733,19 @@ TEST_F(ControlTest, ReceiveUnexpectedDoublePointCommand)
     Thread_sleep(500);
 
     ASSERT_EQ(0, operateHandlerCalled);
+
+    /* expect negative ACT-CON */
+    ASSERT_EQ(1, asduHandlerCalled);
+    ASSERT_EQ(lastCOTReceived, CS101_COT_UNKNOWN_TYPE_ID);
+    ASSERT_TRUE(isNegative);
 }
 
 TEST_F(ControlTest, CommandAckTimeout)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerCommandAckTimeout);
 
@@ -1412,12 +1767,15 @@ TEST_F(ControlTest, CommandAckTimeout)
     Thread_sleep(1000);
 
     ASSERT_EQ(1, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 }
 
 TEST_F(ControlTest, CommandActCon)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerCommandActCon);
 
@@ -1452,16 +1810,18 @@ TEST_F(ControlTest, CommandActCon)
 
     ASSERT_EQ(2, asduHandlerCalled);
     ASSERT_EQ(1, actConReceived);
-    ASSERT_FALSE(actConNegative);
+    ASSERT_FALSE(isNegative);
     ASSERT_EQ(1, actTermReceived);
 }
 
-TEST_F(ControlTest, CommandActConNegative)
+TEST_F(ControlTest, CommandisNegative)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
-    iec104Server->registerControl(operateHandlerCommandActConNegative);
+    iec104Server->registerControl(operateHandlerCommandisNegative);
 
     iec104Server->ActConTimeout(1000);
     iec104Server->ActTermTimeout(1000);
@@ -1489,7 +1849,7 @@ TEST_F(ControlTest, CommandActConNegative)
 
     ASSERT_EQ(1, asduHandlerCalled);
     ASSERT_EQ(1, actConReceived);
-    ASSERT_TRUE(actConNegative);
+    ASSERT_TRUE(isNegative);
     ASSERT_EQ(0, actTermReceived);
 }
 
@@ -1497,6 +1857,8 @@ TEST_F(ControlTest, SinglePointCommandIOMissing)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerSinglePointCommandIOMissing);
 
@@ -1519,12 +1881,85 @@ TEST_F(ControlTest, SinglePointCommandIOMissing)
     Thread_sleep(500);
 
     ASSERT_EQ(0, operateHandlerCalled);
+
+    /* expect negative ACT-CON */
+    ASSERT_EQ(1, asduHandlerCalled);
+    ASSERT_EQ(lastCOTReceived, CS101_COT_UNKNOWN_TYPE_ID);
+    ASSERT_TRUE(isNegative);
+}
+
+TEST_F(ControlTest, ReceiveSinglePointCommandWithoutTimestampNotAllowed)
+{
+    iec104Server->setJsonConfig(protocol_stack_3, exchanged_data, tls);
+    ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
+
+    iec104Server->registerControl(operateHandlerSingleCommand);
+
+    Thread_sleep(500); /* wait for the server to start */
+
+    ASSERT_TRUE(CS104_Connection_connect(connection));
+
+    CS104_Connection_sendStartDT(connection);
+
+    InformationObject sc = (InformationObject)SingleCommand_create(NULL, 23005, true, false, 0);
+
+    CS104_Connection_sendProcessCommandEx(connection, CS101_COT_ACTIVATION, 45, sc);
+
+    InformationObject_destroy(sc);
+
+    Thread_sleep(500);
+
+    ASSERT_EQ(0, operateHandlerCalled);
+
+    /* expect negative ACT-CON */
+    ASSERT_EQ(1, asduHandlerCalled);
+    ASSERT_EQ(lastCOTReceived, CS101_COT_UNKNOWN_TYPE_ID);
+    ASSERT_TRUE(isNegative);
+}
+
+TEST_F(ControlTest, ReceiveSinglePointCommandWithTimestampNotAllowed)
+{
+    iec104Server->setJsonConfig(protocol_stack_2, exchanged_data, tls);
+    ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
+
+    iec104Server->registerControl(operateHandlerReceiveSinglePointCommandWithTime);
+
+    Thread_sleep(500); /* wait for the server to start */
+
+    ASSERT_TRUE(CS104_Connection_connect(connection));
+
+    CS104_Connection_sendStartDT(connection);
+
+    CP56Time2a timestamp = CP56Time2a_createFromMsTimestamp(NULL, Hal_getTimeInMs());
+
+    InformationObject sc = (InformationObject)SingleCommandWithCP56Time2a_create(NULL, 10005, true, false, 0, timestamp);
+
+    CS104_Connection_sendProcessCommandEx(connection, CS101_COT_ACTIVATION, 45, sc);
+
+    InformationObject_destroy(sc);
+
+    free(timestamp);
+
+    Thread_sleep(500);
+
+    ASSERT_EQ(0, operateHandlerCalled);
+
+    /* expect negative ACT-CON */
+    ASSERT_EQ(1, asduHandlerCalled);
+    ASSERT_EQ(lastCOTReceived, CS101_COT_UNKNOWN_TYPE_ID);
+    ASSERT_TRUE(isNegative);
 }
 
 TEST_F(ControlTest, ReceiveSinglePointCommandWithTime)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerReceiveSinglePointCommandWithTime);
 
@@ -1545,6 +1980,7 @@ TEST_F(ControlTest, ReceiveSinglePointCommandWithTime)
     Thread_sleep(500);
 
     ASSERT_EQ(1, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 
     /* wait for time to become to old for configured cmd_exec_timeout parameter */
     Thread_sleep(1200);
@@ -1557,7 +1993,13 @@ TEST_F(ControlTest, ReceiveSinglePointCommandWithTime)
 
     Thread_sleep(500);
 
+    /* no new command since first one as second one had invalid timestamp */
     ASSERT_EQ(1, operateHandlerCalled);
+    
+    /* expect negative ACT-CON */
+    ASSERT_EQ(1, asduHandlerCalled);
+    ASSERT_EQ(1, actConReceived);
+    ASSERT_TRUE(isNegative);
 
     free(timestamp);
 }
@@ -1566,6 +2008,8 @@ TEST_F(ControlTest, ReceiveDoublePointCommand)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerDoublePointCommand);
 
@@ -1584,12 +2028,15 @@ TEST_F(ControlTest, ReceiveDoublePointCommand)
     Thread_sleep(500);
 
     ASSERT_EQ(1, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 }
 
 TEST_F(ControlTest, ReceiveDoublePointCommandWithTime)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerDoublePointCommandWithTime);
 
@@ -1610,6 +2057,7 @@ TEST_F(ControlTest, ReceiveDoublePointCommandWithTime)
     Thread_sleep(500);
 
     ASSERT_EQ(1, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 
     /* wait for time to become to old for configured cmd_exec_timeout parameter */
     Thread_sleep(1200);
@@ -1622,7 +2070,13 @@ TEST_F(ControlTest, ReceiveDoublePointCommandWithTime)
 
     Thread_sleep(500);
 
+    /* no new command since first one as second one had invalid timestamp */
     ASSERT_EQ(1, operateHandlerCalled);
+    
+    /* expect negative ACT-CON */
+    ASSERT_EQ(1, asduHandlerCalled);
+    ASSERT_EQ(1, actConReceived);
+    ASSERT_TRUE(isNegative);
 
     free(timestamp);
 }
@@ -1632,6 +2086,8 @@ TEST_F(ControlTest, ReceiveMultipleSinglePointCommandWithTime)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerMultipleSinglePointCommandWithTime);
 
@@ -1664,6 +2120,7 @@ TEST_F(ControlTest, ReceiveMultipleSinglePointCommandWithTime)
     Thread_sleep(500);
 
     ASSERT_EQ(5, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 
     /* wait for time to become to old for configured cmd_exec_timeout parameter */
     Thread_sleep(1200);
@@ -1688,7 +2145,13 @@ TEST_F(ControlTest, ReceiveMultipleSinglePointCommandWithTime)
 
     Thread_sleep(500);
 
+    /* no new command since first ones as second oned had invalid timestamp */
     ASSERT_EQ(5, operateHandlerCalled);
+    
+    /* expect negative ACT-CON */
+    ASSERT_EQ(5, asduHandlerCalled);
+    ASSERT_EQ(5, actConReceived);
+    ASSERT_TRUE(isNegative);
 
     free(timestamp);
 }
@@ -1697,6 +2160,8 @@ TEST_F(ControlTest, ReceiveStepPointCommand)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerStepPointCommand);
 
@@ -1715,6 +2180,7 @@ TEST_F(ControlTest, ReceiveStepPointCommand)
     Thread_sleep(500);
 
     ASSERT_EQ(1, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 }
 
 
@@ -1722,6 +2188,8 @@ TEST_F(ControlTest, ReceiveStepPointCommandWithTime)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerStepPointCommandWithTime);
 
@@ -1742,11 +2210,12 @@ TEST_F(ControlTest, ReceiveStepPointCommandWithTime)
     Thread_sleep(500);
 
     ASSERT_EQ(1, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 
     /* wait for time to become to old for configured cmd_exec_timeout parameter */
     Thread_sleep(1200);
 
-    rc = (InformationObject)StepCommandWithCP56Time2a_create(NULL, 14005, IEC60870_STEP_INVALID_0 , false, 0, timestamp);
+    rc = (InformationObject)StepCommandWithCP56Time2a_create(NULL, 16005, IEC60870_STEP_INVALID_0 , false, 0, timestamp);
 
     CS104_Connection_sendProcessCommandEx(connection, CS101_COT_ACTIVATION, 45, rc);
 
@@ -1754,7 +2223,13 @@ TEST_F(ControlTest, ReceiveStepPointCommandWithTime)
 
     Thread_sleep(500);
 
+    /* no new command since first one as second one had invalid timestamp */
     ASSERT_EQ(1, operateHandlerCalled);
+    
+    /* expect negative ACT-CON */
+    ASSERT_EQ(1, asduHandlerCalled);
+    ASSERT_EQ(1, actConReceived);
+    ASSERT_TRUE(isNegative);
 
     free(timestamp);
 }
@@ -1763,6 +2238,8 @@ TEST_F(ControlTest, ReceiveSetPointCommandNormalized)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerSetPointCommandNormalized);
 
@@ -1781,12 +2258,15 @@ TEST_F(ControlTest, ReceiveSetPointCommandNormalized)
     Thread_sleep(500);
 
     ASSERT_EQ(1, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 }
 
 TEST_F(ControlTest, ReceiveSetPointCommandNormalizedWithTime)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerSetPointCommandNormalizedWithTime);
 
@@ -1807,6 +2287,7 @@ TEST_F(ControlTest, ReceiveSetPointCommandNormalizedWithTime)
     Thread_sleep(500);
 
     ASSERT_EQ(1, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 
     /* wait for time to become to old for configured cmd_exec_timeout parameter */
     Thread_sleep(1200);
@@ -1819,7 +2300,13 @@ TEST_F(ControlTest, ReceiveSetPointCommandNormalizedWithTime)
 
     Thread_sleep(500);
 
+    /* no new command since first one as second one had invalid timestamp */
     ASSERT_EQ(1, operateHandlerCalled);
+    
+    /* expect negative ACT-CON */
+    ASSERT_EQ(1, asduHandlerCalled);
+    ASSERT_EQ(1, actConReceived);
+    ASSERT_TRUE(isNegative);
 
     free(timestamp);
 }
@@ -1829,6 +2316,8 @@ TEST_F(ControlTest, ReceiveSetPointCommandScaled)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerSetPointCommandScaled);
 
@@ -1847,6 +2336,7 @@ TEST_F(ControlTest, ReceiveSetPointCommandScaled)
     Thread_sleep(500);
 
     ASSERT_EQ(1, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 }
 
 
@@ -1854,6 +2344,8 @@ TEST_F(ControlTest, ReceiveSetPointCommandScaledWithTime)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerSetPointCommandScaledWithTime);
 
@@ -1874,6 +2366,7 @@ TEST_F(ControlTest, ReceiveSetPointCommandScaledWithTime)
     Thread_sleep(500);
 
     ASSERT_EQ(1, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 
     /* wait for time to become to old for configured cmd_exec_timeout parameter */
     Thread_sleep(1200);
@@ -1886,7 +2379,13 @@ TEST_F(ControlTest, ReceiveSetPointCommandScaledWithTime)
 
     Thread_sleep(500);
 
+    /* no new command since first one as second one had invalid timestamp */
     ASSERT_EQ(1, operateHandlerCalled);
+    
+    /* expect negative ACT-CON */
+    ASSERT_EQ(1, asduHandlerCalled);
+    ASSERT_EQ(1, actConReceived);
+    ASSERT_TRUE(isNegative);
 
     free(timestamp);
 }
@@ -1895,6 +2394,8 @@ TEST_F(ControlTest, ReceiveSetPointCommandShort)
 {
     iec104Server->setJsonConfig(protocol_stack, exchanged_data, tls);
     ASSERT_TRUE(iec104Server->startSlave());
+    // Simulate open connecion with south plugin
+    SendSouthEvent("CONSTAT-1", true, "started", false, "");
 
     iec104Server->registerControl(operateHandlerSetPointCommandShort);
 
@@ -1913,4 +2414,5 @@ TEST_F(ControlTest, ReceiveSetPointCommandShort)
     Thread_sleep(500);
 
     ASSERT_EQ(1, operateHandlerCalled);
+    ASSERT_EQ(0, asduHandlerCalled);
 }


### PR DESCRIPTION
Added automatic negative ACK response for commands received when south plugin in not connected to its device.

Streamlined other existing cases generating automatic command ACKs to ensure they all use the negative flag and all have a relevant COT.